### PR TITLE
Fix: Make ChatTree work with all languages

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "ChatTree",
     "description": "Visualize ChatGPT and Claude.ai conversations as interactive trees",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "manifest_version": 3,
     "icons": {
         "16": "logo16.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -994,7 +994,6 @@ async function selectBranch(stepsToTake: any[]) {
     await chrome.scripting.executeScript({
       target: { tabId: currentTab.id },
       func: (stepsToTake) => {
-        console.log("stepsToTake", stepsToTake);
 
         // Function to trigger native events on a specific element
         function triggerNativeEvents(element: Element) {

--- a/src/utils/nodeNavigation.ts
+++ b/src/utils/nodeNavigation.ts
@@ -6,6 +6,7 @@ export const calculateSteps = (nodes: OpenAINode[], targetId: string) => {
     nodeId: string;
     stepsLeft: number;
     stepsRight: number;
+    role: string;
   }> = [];
 
   let currentNode = nodes.find((node) => node.id === targetId);
@@ -36,6 +37,7 @@ export const calculateSteps = (nodes: OpenAINode[], targetId: string) => {
             nodeId: parent.children[i],
             stepsLeft: -1,
             stepsRight: 1,
+            role: currentNode.data.role!,
           });
         }
       } else {
@@ -58,6 +60,7 @@ export const calculateSteps = (nodes: OpenAINode[], targetId: string) => {
             nodeId: parent.children[tempActiveChildIndex],
             stepsLeft: moveRight ? -1 : 1,
             stepsRight: moveRight ? 1 : -1,
+            role: currentNode.data.role!,
           });
         }
 


### PR DESCRIPTION
This PR removes the aria-label searches in the DOM and instead uses fixed button positions which makes it work with all languages instead of only english. This fixes #11  