### PR TITLE
feat(ui): add persisted dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import Tree from "./components/ConversationTree";
 
 function App() {
   return (
-    <div className="w-full h-screen flex flex-col">
+    <div className="w-full h-screen flex flex-col bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors">
       <div className="flex-1 overflow-hidden">
         <Tree />
       </div>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -142,23 +142,23 @@ export const ContextMenu = (props: ContextMenuProps) => {
         <div
             ref={menuRef}
             style={getPositionStyle()}
-            className="bg-white shadow-lg rounded-lg p-3 z-50 min-w-[180px]"
+            className="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-3 z-50 min-w-[180px]"
         >
             {props.role && (
-                <div className="px-2 py-1 text-xs text-gray-500 border-b border-gray-100">
+                <div className="px-2 py-1 text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
                     Role: {props.role}
                 </div>
             )}
             <div className="mt-1 space-y-1">
                 <button 
-                    className="w-full px-2 py-1.5 text-sm text-left text-gray-700 hover:bg-gray-50 rounded transition-colors" 
+                    className="w-full px-2 py-1.5 text-sm text-left text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded transition-colors"
                     onClick={selectBranch}
                 >
                     Select
                 </button>
                 {hasChildren && (
                     <button 
-                        className="w-full px-2 py-1.5 text-sm text-left text-gray-700 hover:bg-gray-50 rounded transition-colors" 
+                        className="w-full px-2 py-1.5 text-sm text-left text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded transition-colors"
                         onClick={handleActionClick}
                     >
                         {props.role === 'user' || props.role === 'human' ? 'Edit this message' : 'Respond to this message'}
@@ -175,12 +175,12 @@ export const ContextMenu = (props: ContextMenuProps) => {
                                         handleSend();
                                     }
                                 }}
-                                className="w-full px-4 py-2 text-sm text-gray-700 border rounded-lg focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 min-h-[100px] resize-y"
+                                className="w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-100 bg-white dark:bg-gray-900 border rounded-lg border-gray-300 dark:border-gray-700 focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 min-h-[100px] resize-y"
                                 placeholder={props.role === 'user' || props.role === 'human' ? "Edit message..." : "Type your response..."}
                                 autoFocus
                             />
                             <div className="flex justify-between items-center mt-2">
-                                <span className="text-xs text-gray-500">Press ⌘+Enter to send</span>
+                                <span className="text-xs text-gray-500 dark:text-gray-400">Press ⌘+Enter to send</span>
                                 <button 
                                     onClick={handleSend}
                                     className="px-3 py-1 text-sm text-white bg-blue-500 rounded hover:bg-blue-600 transition-colors disabled:opacity-50"

--- a/src/components/ConversationTree.tsx
+++ b/src/components/ConversationTree.tsx
@@ -3,6 +3,7 @@ import { ReactFlow, addEdge, Connection, MiniMap, Controls, Background, Backgrou
 import { ContextMenu } from './ContextMenu';
 import { LoadingSpinner, ErrorState } from "./LoadingStates";
 import { useConversationTree } from '../hooks/useConversationTree';
+import { useThemePreference } from '../hooks/useThemePreference';
 import { createContextMenuHandler, checkNodes, checkNodesClaude, createClaudeContextMenuHandler } from '../utils/conversationTreeHandlers';
 import { createNodesInOrder } from '../utils/nodeCreation';
 import { createClaudeNodesInOrder} from '../utils/claudeNodeCreation';
@@ -53,6 +54,8 @@ const ConversationTree = () => {
   const [showSearch, setShowSearch] = useState(false);
   const [lastActiveChildMap, setLastActiveChildMap] = useState<Record<string, string>>({});
   const [previousPathNodeIds, setPreviousPathNodeIds] = useState<Set<string>>(new Set());
+
+  const { preference, resolvedTheme, isDark, cyclePreference } = useThemePreference();
 
   // Create nodes and edges when conversation data changes
   useEffect(() => {
@@ -282,24 +285,62 @@ const ConversationTree = () => {
 
   return (
     <div className="w-full h-full" style={{ height: '100%', width: '100%' }}>
-      <div className="absolute top-4 right-4 flex items-center bg-white rounded-lg shadow-lg divide-x divide-gray-200 z-10">
+      <div className="absolute top-4 right-4 flex items-center bg-white dark:bg-gray-800 rounded-lg shadow-lg divide-x divide-gray-200 dark:divide-gray-700 z-10">
         <button
           onClick={() => setShowSearch(true)}
-          className="p-2.5 hover:bg-gray-50 transition-colors rounded-l-lg group"
+          className="p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded-l-lg group"
           title="Search messages (⌘+K)"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800" viewBox="0 0 20 20" fill="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" />
           </svg>
         </button>
         <button
           onClick={handleRefresh}
-          className="p-2.5 hover:bg-gray-50 transition-colors group"
+          className="p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"
           title="Refresh conversation"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800" viewBox="0 0 20 20" fill="currentColor">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100" viewBox="0 0 20 20" fill="currentColor">
             <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
           </svg>
+        </button>
+        <button
+          onClick={cyclePreference}
+          className="p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"
+          title={`Theme: ${preference} (${resolvedTheme})`}
+          aria-label="Change theme"
+        >
+          {isDark ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M7.05 16.95l-1.414 1.414m12.728 0l-1.414-1.414M7.05 7.05L5.636 5.636M12 8a4 4 0 100 8 4 4 0 000-8z"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"
+              />
+            </svg>
+          )}
         </button>
         <CopyButton 
           nodes={nodes} 
@@ -309,7 +350,7 @@ const ConversationTree = () => {
         <ExportButton 
           nodes={nodes} 
           conversationData={conversationData}
-          className="p-2.5 hover:bg-gray-50 transition-colors rounded-r-lg group"
+          className="p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded-r-lg group"
         />
       </div>
       <ReactFlow
@@ -325,18 +366,30 @@ const ConversationTree = () => {
         onInit={instance => { 
           reactFlowInstance.current = instance;
         }}
+        colorMode={resolvedTheme}
         fitView
         proOptions={{ hideAttribution: true }}
         minZoom={0.1}
         maxZoom={1.5}
         defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
       >
-        <Controls className="bg-white rounded-lg shadow-lg" />
+        <Controls className="bg-white dark:bg-gray-800 rounded-lg shadow-lg" />
         <MiniMap 
-          nodeColor={(node) => node.data?.role === 'user' ? '#fefce8' : '#f9fafb'}
-          className="bg-white rounded-lg shadow-lg"
+          nodeColor={(node) => {
+            const isUser = node.data?.role === 'user' || node.data?.role === 'human';
+            if (isDark) {
+              return isUser ? '#f59e0b' : '#9ca3af';
+            }
+            return isUser ? '#fefce8' : '#f9fafb';
+          }}
+          className="bg-white dark:bg-gray-800 rounded-lg shadow-lg"
         />
-        <Background variant={BackgroundVariant.Dots} gap={12} size={1} color="#f1f1f1" />
+        <Background
+          variant={BackgroundVariant.Dots}
+          gap={12}
+          size={1}
+          color={isDark ? '#334155' : '#f1f1f1'}
+        />
         {menu && <ContextMenu 
           provider={provider}
           onClick={onPaneClick} 

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -30,11 +30,12 @@ export const CopyButton = ({ nodes, onNodeClick, provider = 'openai' }: CopyButt
     <>
       <button
         onClick={() => setIsModalOpen(true)}
-        className="p-2 text-gray-600 hover:text-gray-800 transition-colors"
+        className="p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"
+        title="Copy conversation"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          className="h-4 w-4"
+          className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"

--- a/src/components/CopyModal.tsx
+++ b/src/components/CopyModal.tsx
@@ -55,50 +55,50 @@ export const CopyModal = ({ onClose, onCopy, nodes, onNodeClick, provider = 'ope
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Copy Conversation</h3>
-        <p className="text-sm text-gray-600 mb-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Copy Conversation</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
           Select the messages you want to copy to clipboard in markdown format.
           <br />
-          <span className="text-xs text-gray-500">Right-click a message to navigate to it in the conversation.</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">Right-click a message to navigate to it in the conversation.</span>
         </p>
         
         <div className="flex gap-2 mb-4">
           <button
             onClick={handleSelectAll}
-            className="text-sm text-blue-600 hover:text-blue-800"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
           >
             Select All
           </button>
           <button
             onClick={handleDeselectAll}
-            className="text-sm text-blue-600 hover:text-blue-800"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300"
           >
             Deselect All
           </button>
         </div>
 
-        <div className="max-h-96 overflow-y-auto mb-4 border border-gray-200 rounded-lg">
+        <div className="max-h-96 overflow-y-auto mb-4 border border-gray-200 dark:border-gray-700 rounded-lg">
           {visibleNodes.map(node => (
             <div
               key={node.id}
-              className={`p-3 border-b border-gray-200 last:border-b-0 cursor-pointer transition-colors ${
+              className={`p-3 border-b border-gray-200 dark:border-gray-700 last:border-b-0 cursor-pointer transition-colors ${
                 selectedNodeIds.includes(node.id)
-                  ? 'bg-blue-100 hover:bg-blue-200'
-                  : 'hover:bg-gray-50'
+                  ? 'bg-blue-100 hover:bg-blue-200 dark:bg-blue-900/40 dark:hover:bg-blue-900/60'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-700/60'
               }`}
               onClick={() => handleNodeToggle(node.id)}
               onContextMenu={(e) => handleContextMenu(e, node)}
             >
               <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-900">
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
                   {node.data?.role === 'user' ? 'You' : 'Assistant'}
                 </span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-gray-500 dark:text-gray-400">
                   {node.data?.timestamp ? new Date(node.data.timestamp * 1000).toLocaleString() : ''}
                 </span>
               </div>
-              <div className="mt-1 text-sm text-gray-700 line-clamp-2">
+              <div className="mt-1 text-sm text-gray-700 dark:text-gray-200 line-clamp-2">
                 {node.data?.label}
               </div>
             </div>
@@ -108,7 +108,7 @@ export const CopyModal = ({ onClose, onCopy, nodes, onNodeClick, provider = 'ope
         <div className="flex justify-end gap-3">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+            className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
           >
             Cancel
           </button>

--- a/src/components/CustomNode.tsx
+++ b/src/components/CustomNode.tsx
@@ -19,23 +19,26 @@ export const CustomNode = ({ data }: { data: any }) => {
       } else if (role === 'assistant') {
         return { /* assistant styles */ };
       } else if (role === 'system') {
-        return { 
-          backgroundColor: '#ffffff',
-          border: '1px solid #000000',
-          borderRadius: '4px',
-          // Add any other styling you want for the system/start node
-        };
+        return {};
       } else {
         return { /* default styles */ };
       }
     };
   
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    const hiddenBackground =
+      data.hidden && !isExpanded
+        ? isDarkMode
+          ? 'repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(255,255,255,0.05) 10px, rgba(255,255,255,0.05) 20px)'
+          : 'repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(0,0,0,0.03) 10px, rgba(0,0,0,0.03) 20px)'
+        : undefined;
+
     return (
       <>
         <div 
           // Dynamic classes for styling based on role (user/assistant), visibility, and expansion state
           className={`px-4 py-2 shadow-lg rounded-lg border transition-all duration-300 
-            ${data.role === 'user' || data.role === 'human' ? 'bg-yellow-50 border-yellow-200' : data.role === 'assistant' ? 'bg-gray-50 border-gray-200' : 'bg-gray-50 border-gray-200'}
+            ${data.role === 'user' || data.role === 'human' ? 'bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-900' : data.role === 'assistant' ? 'bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-700' : 'bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-700'}
             ${data.hidden ? 'grayscale' : ''}
             ${isExpanded ? 'fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 w-[80vw] h-[80vh]' : ''}
           `} 
@@ -45,7 +48,7 @@ export const CustomNode = ({ data }: { data: any }) => {
             height: isExpanded ? undefined : nodeHeight,
             position: isExpanded ? 'fixed' : 'relative',
             opacity: data.hidden && !isExpanded ? 0.4 : 1,
-            background: data.hidden && !isExpanded ? 'repeating-linear-gradient(45deg, transparent, transparent 10px, rgba(0,0,0,0.03) 10px, rgba(0,0,0,0.03) 20px)' : undefined,
+            background: hiddenBackground,
             ...getNodeStyle(data.role)
           }}
           onDoubleClick={() => setIsExpanded(!isExpanded)}
@@ -59,10 +62,10 @@ export const CustomNode = ({ data }: { data: any }) => {
               <div className={`w-2 h-2 rounded-full mr-2 ${
                 data.role === 'user' ? 'bg-yellow-400' : data.role === 'assistant' ? 'bg-gray-400' : 'bg-gray-400'
               }`} />
-              <div className="text-xs font-semibold text-gray-500 uppercase">
+              <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">
                 {data.role}
                 {data.role === 'assistant' && data.model_slug && (
-                  <span className="ml-2 font-normal text-gray-400 italic lowercase">
+                  <span className="ml-2 font-normal text-gray-400 dark:text-gray-500 italic lowercase">
                     {data.model_slug}
                   </span>
                 )}
@@ -79,7 +82,7 @@ export const CustomNode = ({ data }: { data: any }) => {
           </div>
   
           {/* Message content with markdown support */}
-          <div className={`mt-2 text-sm text-gray-700 ${
+          <div className={`mt-2 text-sm text-gray-700 dark:text-gray-200 ${
             isExpanded  
               ? 'h-[calc(100%-100px)] overflow-y-auto nowheel' 
               : 'line-clamp-3'
@@ -92,7 +95,7 @@ export const CustomNode = ({ data }: { data: any }) => {
   
           {/* Timestamp display */}
           {data.timestamp && (
-            <div className="absolute bottom-2 left-4 text-xs text-gray-400">
+            <div className="absolute bottom-2 left-4 text-xs text-gray-400 dark:text-gray-500">
               {new Date(parseFloat(data.timestamp) * 1000).toLocaleString()} 
             </div>
           )}
@@ -103,7 +106,7 @@ export const CustomNode = ({ data }: { data: any }) => {
           {/* Close button for expanded view */}
           {isExpanded && (
             <button 
-              className="absolute top-4 right-4 p-2 hover:bg-gray-100 rounded-full"
+              className="absolute top-4 right-4 p-2 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full"
               onClick={() => setIsExpanded(false)}
             >
               ✕

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -208,10 +208,10 @@ export const ExportButton = ({ nodes, conversationData, className }: ExportButto
     <>
       <button
         onClick={() => setShowModal(true)}
-        className={className || "p-2.5 hover:bg-gray-50 transition-colors group"}
+        className={className || "p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"}
         title="Export conversation"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100" viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
         </svg>
       </button>

--- a/src/components/ExportButtonClaude.tsx
+++ b/src/components/ExportButtonClaude.tsx
@@ -113,10 +113,10 @@ export const ExportButtonClaude = ({ nodes, conversationData, className }: Expor
     <>
       <button
         onClick={() => setShowModal(true)}
-        className={className || "p-2.5 hover:bg-gray-50 transition-colors group"}
+        className={className || "p-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors group"}
         title="Export conversation"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800" viewBox="0 0 20 20" fill="currentColor">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 group-hover:text-gray-800 dark:text-gray-300 dark:group-hover:text-gray-100" viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
         </svg>
       </button>

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -7,9 +7,9 @@ interface ExportModalProps {
 export const ExportModal = ({ onClose, onExport, visibleNodesCount }: ExportModalProps) => {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Export Conversation</h3>
-        <p className="text-sm text-gray-600 mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Export Conversation</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-300 mb-6">
           Only the currently visible branch ({visibleNodesCount} messages) will be exported.
         </p>
         <div className="flex flex-col gap-3">
@@ -34,7 +34,7 @@ export const ExportModal = ({ onClose, onExport, visibleNodesCount }: ExportModa
         </div>
         <button
           onClick={onClose}
-          className="mt-4 text-gray-500 hover:text-gray-700 text-sm"
+          className="mt-4 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 text-sm"
         >
           Cancel
         </button>

--- a/src/components/LoadingStates.tsx
+++ b/src/components/LoadingStates.tsx
@@ -1,11 +1,11 @@
 export const LoadingSpinner = () => (
-  <div className="flex items-center justify-center h-screen">
+  <div className="flex items-center justify-center h-screen bg-gray-50 dark:bg-gray-900">
     <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-blue-500"></div>
   </div>
 );
 
 export const ErrorState = () => (
-  <div className="flex items-center justify-center h-screen text-gray-600">
+  <div className="flex items-center justify-center h-screen text-gray-600 dark:text-gray-300">
     No chat found, please refresh the web page and try again!
   </div>
 ); 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -139,7 +139,7 @@ export const SearchBar = ({ nodes, onNodeClick, onClose, onRefresh, provider }: 
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-start justify-center pt-20 z-50">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl mx-4">
         <div className="p-4">
           <div className="flex items-center space-x-2">
             <input
@@ -148,9 +148,9 @@ export const SearchBar = ({ nodes, onNodeClick, onClose, onRefresh, provider }: 
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search messages... (⌘+K)"
-              className="w-full px-4 py-2 text-lg border-none focus:outline-none focus:ring-0"
+              className="w-full px-4 py-2 text-lg border-none bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-400 focus:outline-none focus:ring-0"
             />
-            <kbd className="px-2 py-1 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">
+            <kbd className="px-2 py-1 text-xs font-semibold text-gray-800 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg">
               esc
             </kbd>
           </div>
@@ -158,30 +158,30 @@ export const SearchBar = ({ nodes, onNodeClick, onClose, onRefresh, provider }: 
         
         {results.length > 0 ? (
           <>
-            <div className="border-t border-gray-200" />
+            <div className="border-t border-gray-200 dark:border-gray-700" />
             <div className="max-h-96 overflow-y-auto">
               {results.map((result, index) => (
                 <button
                   key={result.nodeId}
                   onClick={() => handleResultClick(result)}
-                  className={`w-full px-4 py-3 text-left hover:bg-gray-50 focus:outline-none ${
-                    index === selectedIndex ? 'bg-gray-50' : ''
+                  className={`w-full px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none ${
+                    index === selectedIndex ? 'bg-gray-50 dark:bg-gray-700' : ''
                   }`}
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-2">
-                      <span className="text-sm font-medium text-gray-900">
+                      <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
                         {result.node.data?.role === (provider === 'openai' ? 'user' : 'human') ? 'You' : 'Assistant'}
                       </span>
-                      <span className="text-sm text-gray-500">
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
                         {new Date((result.node.data?.timestamp || 0) * 1000).toLocaleString()}
                       </span>
                     </div>
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
                       {result.matches} match{result.matches !== 1 ? 'es' : ''}
                     </span>
                   </div>
-                  <div className="mt-1 text-sm text-gray-700 line-clamp-2">
+                  <div className="mt-1 text-sm text-gray-700 dark:text-gray-200 line-clamp-2">
                     {result.preview}
                   </div>
                 </button>
@@ -189,7 +189,7 @@ export const SearchBar = ({ nodes, onNodeClick, onClose, onRefresh, provider }: 
             </div>
           </>
         ) : query ? (
-          <div className="px-4 py-8 text-center text-gray-500">
+          <div className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
             No results found
           </div>
         ) : null}

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,2 +1,4 @@
 export const nodeWidth = 300;
 export const nodeHeight = 120;
+
+export const THEME_PREFERENCE_STORAGE_KEY = 'chattree.themePreference';

--- a/src/hooks/useThemePreference.ts
+++ b/src/hooks/useThemePreference.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { THEME_PREFERENCE_STORAGE_KEY } from '../constants/constants';
+import { storageLocalGet, storageLocalSet } from '../utils/storageLocal';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'system' || value === 'light' || value === 'dark';
+}
+
+function applyResolvedTheme(theme: ResolvedTheme) {
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function useThemePreference() {
+  const [preference, setPreferenceState] = useState<ThemePreference>('system');
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() => {
+    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ?? false;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
+    if (!mediaQuery) {
+      return;
+    }
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemPrefersDark(event.matches);
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const load = async () => {
+      const storedPreference = await storageLocalGet<unknown>(THEME_PREFERENCE_STORAGE_KEY);
+      if (isCancelled) {
+        return;
+      }
+
+      if (isThemePreference(storedPreference)) {
+        setPreferenceState(storedPreference);
+      }
+    };
+
+    load();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  const resolvedTheme: ResolvedTheme = useMemo(() => {
+    if (preference === 'system') {
+      return systemPrefersDark ? 'dark' : 'light';
+    }
+
+    return preference;
+  }, [preference, systemPrefersDark]);
+
+  useEffect(() => {
+    applyResolvedTheme(resolvedTheme);
+  }, [resolvedTheme]);
+
+  const setPreference = useCallback((nextPreference: ThemePreference) => {
+    setPreferenceState(nextPreference);
+    storageLocalSet(THEME_PREFERENCE_STORAGE_KEY, nextPreference);
+  }, []);
+
+  const toggleDark = useCallback(() => {
+    setPreference(resolvedTheme === 'dark' ? 'light' : 'dark');
+  }, [resolvedTheme, setPreference]);
+
+  const cyclePreference = useCallback(() => {
+    setPreference(
+      preference === 'system'
+        ? 'light'
+        : preference === 'light'
+          ? 'dark'
+          : 'system'
+    );
+  }, [preference, setPreference]);
+
+  return {
+    preference,
+    resolvedTheme,
+    isDark: resolvedTheme === 'dark',
+    setPreference,
+    toggleDark,
+    cyclePreference,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -36,3 +36,28 @@ body {
 .react-flow__attribution {
   display: none;
 }
+
+html.dark,
+html.dark body {
+  background-color: #111827;
+}
+
+.dark .react-flow__controls {
+  background-color: #1f2937;
+  border: 1px solid #374151;
+}
+
+.dark .react-flow__controls-button {
+  background-color: transparent;
+  color: #e5e7eb;
+  border-color: #374151;
+}
+
+.dark .react-flow__controls-button:hover {
+  background-color: #374151;
+}
+
+.dark .react-flow__minimap {
+  background-color: #1f2937;
+  border: 1px solid #374151;
+}

--- a/src/utils/storageLocal.ts
+++ b/src/utils/storageLocal.ts
@@ -1,0 +1,32 @@
+export async function storageLocalGet<T>(key: string): Promise<T | undefined> {
+  if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+    return undefined;
+  }
+
+  return await new Promise((resolve) => {
+    chrome.storage.local.get([key], (result) => {
+      if (chrome.runtime?.lastError) {
+        console.error('storageLocalGet error:', chrome.runtime.lastError);
+        resolve(undefined);
+        return;
+      }
+
+      resolve(result[key] as T | undefined);
+    });
+  });
+}
+
+export async function storageLocalSet<T>(key: string, value: T): Promise<void> {
+  if (typeof chrome === 'undefined' || !chrome.storage?.local) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    chrome.storage.local.set({ [key]: value }, () => {
+      if (chrome.runtime?.lastError) {
+        console.error('storageLocalSet error:', chrome.runtime.lastError);
+      }
+      resolve();
+    });
+  });
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add a dark mode toggle to the side panel toolbar with a system/light/dark cycle
- persist theme preference in `chrome.storage.local` and apply via the root `dark` class
- add dark theme styling for core UI surfaces, modals, and ReactFlow controls

## Testing
- `npm run build`

## Notes
- Lint currently fails due to pre-existing issues in the repo